### PR TITLE
Opsera Hummingbird AI: Converted Bamboo plan TEST-TEST to GHA

### DIFF
--- a/.github/workflows/TEST-TEST.yml
+++ b/.github/workflows/TEST-TEST.yml
@@ -1,0 +1,27 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - test
+  workflow_dispatch:
+
+jobs:
+  spring:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+  default_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+
+### Note:
+# The Bamboo polling trigger logic is replaced with GitHub's push trigger.
+# Bamboo branch management and integration strategy are not directly translatable.
+# Manual branch creation and deletion settings need to be managed outside this YAML.
+# Permissions and plan-level settings in Bamboo do not have direct equivalents in GitHub Actions.


### PR DESCRIPTION


pipeline migrated from Bamboo plan [TEST-TEST](https://bamboo.shared-private.opsera.io/browse/TEST-TEST) to GitHub Actions using Opsera Hummingbird AI
---

### Action Items:
- [ ] Add respective GitHub secrets to run workflow if needed.
- [ ] Review manual trigger replacements since GitHub Actions uses 'workflow_dispatch' for manual triggers.
- [ ] Manage branch strategies and integration policies manually in GitHub repository settings.
- [ ] Adjust permissions through GitHub repository settings as Bamboo plan permissions do not directly map to GitHub Actions.
